### PR TITLE
Clean up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 __pycache__
 .venv/
 *.code-workspace
-settings.json
 TESTENV.py
-[0-9]*.json
-_*.json
+*.json

--- a/dicelib.py
+++ b/dicelib.py
@@ -67,22 +67,19 @@ def rolling_time(dice_amount: int, dice_type: int) -> list[int]:
     return [randint(1, dice_type) for _ in range(dice_amount)]    
 
 
-# def parse_arguments(op1: str, op2: str, op3: str) -> tuple:
 def parse_arguments(*ops) -> tuple:
     """
-    Parses any additional operation given by a roll command and returns
-    them in a deterministic order.
+    Parses any number of operations given by a roll command and returns
+    a dictionary of results.
 
     Params:
-        op1: The first operation given
-        op2: The second operation given
+        ops: The list of passed operations to be made
 
     Returns:
-        (bool, choice | None, modifier | None)
+        (bool, dict)
         
-        bool:     Whether or not the operations given were valid
-        choice:   The dice filtering option (if one is provided)
-        modifier: The stat modifier (if one is provided)
+        bool:   Whether or not the operations given were valid
+        dict:   The parsed dictionary of data
     """
 
     adv_arg = False
@@ -114,12 +111,12 @@ def parse_arguments(*ops) -> tuple:
 
         elif op in {"sav", "save"}:
             if res["save_roll"]:
-                return [False, res]
+                return (False, res)
             res["save_roll"] = True
 
         elif get_lazy_key(adv_keys, op) or get_lazy_key(dis_keys, op):
             if res["choice"] is not None:
-                return [False, res]
+                return (False, res)
 
             adv_arg = True
             res["choice"] = "h1" if get_lazy_key(adv_keys, op) else "l1"
@@ -127,43 +124,40 @@ def parse_arguments(*ops) -> tuple:
         
         elif (lkey := get_lazy_key(skill_keys, op, 4)):
             if res["skill"] is not None:
-                return [False, res]
+                return (False, res)
             res["skill"] = lkey
             
         elif (lkey := get_lazy_key(stat_keys, op)):
             if res["stat"] is not None:
-                return [False, res]
+                return (False, res)
             res["stat"] = lkey
             
         elif is_choice(op):
             if res["choice"] is not None:
-                return [False, res]
+                return (False, res)
             res["choice"] = op
 
         elif is_number(op):
             res["flats"].append(int(op))
 
         else:
-            return [False, res]
+            return (False, res)
 
     if adv_arg:
         match res["to_roll"][0].lower():
-            case "1" | "d":
-                res["to_roll"] = "2" + res["to_roll"]
+            case "1" | "d": res["to_roll"] = "2" + res["to_roll"]
 
-    return [True, res]
+    return (True, res)
 
 
-# def get_roll_results(char, op1: str, op2: str, op3: str) -> tuple:
 def get_roll_results(char, *ops) -> tuple:
     """
     Returns the results of a roll command.
 
     Params:
-        to_roll: The dice rolling instruction
-        op1: The first extra operation
-        op2: The second extra operation
-    
+        char: The character object making the roll, if one exists
+        ops: The list of passed operations to be made
+            
     Returns:
         (str | None, discord.Embed | None)
 

--- a/discordlib.py
+++ b/discordlib.py
@@ -11,9 +11,14 @@ def create_roll_embed(character, dice_type: int, rolls: list[int], selection: li
     Creates and returns an embed to display the results of a roll command.
 
     Params:
+        character: The character object making the roll, if one exists
+        dice_type: The type of dice roll it is
         rolls: This list of resulting rolls made
         selection: The filtered selection, if one exists
-        modifier: The additional modifier, if one exists
+        stat: The additional stat modifier, if one exists
+        skill: The additional skill modifier, if one exists
+        flats: Any additional flat modifiers
+        save_roll: Whether the roll is considered a save roll
 
     Returns:
         discord.Embed: A rich discord embed object containing the results of the

--- a/discordlib.py
+++ b/discordlib.py
@@ -6,7 +6,7 @@ from characterlib import Character
 embed_thumbnail = "https://i.imgur.com/jrDS0br.png"
 
 
-def create_roll_embed(character, dice_type: int, rolls: list[int], selection: list[int] = None, modifier: int|str = None, prof: int|str = None, save_roll = False) -> discord.Embed:
+def create_roll_embed(character, dice_type: int, rolls: list[int], selection: list[int] = None, stat: str = None, skill: str = None, flats : list[int] = None, save_roll = False, **args) -> discord.Embed:
     """
     Creates and returns an embed to display the results of a roll command.
 
@@ -20,12 +20,11 @@ def create_roll_embed(character, dice_type: int, rolls: list[int], selection: li
             roll command
     """
 
-    skill = get_lazy_key(skill_keys, prof, 4)
     roll_type = f"D{dice_type} "
     
     if skill:
         roll_type = f"{skill.capitalize()}\n"
-    elif modifier and (key := get_lazy_key(stat_keys, modifier)):
+    elif stat and (key := get_lazy_key(stat_keys, stat)):
         roll_type = f"{key.capitalize()}\n"
 
     group = selection if selection is not None else rolls
@@ -47,46 +46,45 @@ def create_roll_embed(character, dice_type: int, rolls: list[int], selection: li
     if selection:
         embed.add_field(name="Selection", value=", ".join([str(n) for n in selection]))
     
+    stat_mod = 0
     prof_mod = 0
     save_mod = 0
     
-    if modifier is not None or prof is not None or save_mod is not None:
+    if stat is not None or skill is not None or save_mod is not None:
         modstr = ""
-        mod_stat = get_lazy_key(stat_keys, modifier)
 
         # Stat modifier
-        if type(modifier) is str and character:
-            modifier = character.get_stat_modifier(mod_stat)
-            modstr += f"{modifier:+} ({mod_stat.upper()[:3]})\n"
+        if stat and character:
+            stat_mod = character.get_stat_modifier(stat)
+            modstr += f"{stat_mod:+} ({stat.upper()[:3]})\n"
 
-        # elif type(prof) is str and character:
         elif skill and character:
             stat = get_lazy_key(stat_keys, skill_keys[skill])
-            modifier = character.get_stat_modifier(stat)
-            modstr += f"{modifier:+} ({stat.upper()[:3]})\n"
+            stat_mod = character.get_stat_modifier(stat)
+            modstr += f"{stat_mod:+} ({stat.upper()[:3]})\n"
 
-        elif modifier is not None and type(modifier) is int:
-            modstr = f"{modifier:+}"
-        
         # Proficiency modifier
         if skill and character and (prof_lvl := character.get_proficiency(skill)) > 0:
             prof_mod = character.get_proficiency_modifier(skill)
-            modstr += f"{prof_mod:+} ({"EXP" if prof_lvl > 1 else "PRO"})"
+            modstr += f"{prof_mod:+} ({"EXP" if prof_lvl > 1 else "PRO"})\n"
         
         # Save roll
-        if save_roll and mod_stat and mod_stat in job_keys[character.job]["saving_throws"]:
+        if save_roll and stat and stat in job_keys[character.job]["saving_throws"]:
             save_mod = Character.proficiency_calculation(character.level)
-            modstr += f"{save_mod:+} (SAVE)"
+            modstr += f"{save_mod:+} (SAVE)\n"
+
+        # Flat modifiers
+        if flats is not None:
+            for num in flats:
+                modstr += f"{num:+}\n"
 
         if modstr:
             embed.add_field(name="Modifier", value=modstr)
     
-    if modifier is None or not type(modifier) is int:
-        # w00t: Hard set modifier to 0 for sum calculation
-        modifier = 0
-
     result = sum(selection) if selection else sum(rolls)
-    total = result + modifier + prof_mod + save_mod
+    flat_sum = sum(flats) if flats is not None else 0
+    total = result + stat_mod + prof_mod + save_mod + flat_sum
+    
     embed.add_field(name="Result", value=f'{total}', inline=False)
     
     return embed

--- a/main.py
+++ b/main.py
@@ -84,16 +84,16 @@ async def register_dm(ctx, user : discord.Member = None):
 
 
 @bot.command(name="roll")
-async def roll_dice(ctx, op1 = None, op2 = None, op3 = None):
+async def roll_dice(ctx, *ops):
     character = get_character(ctx.author.id)
-    string, embed = get_roll_results(character, op1, op2, op3)
+    string, embed = get_roll_results(character, *ops)
     await send_message(ctx.channel, string, embed)
 
 
 @bot.command(name="rolldm")
-async def roll_dice_dm(ctx, op1 = None, op2 = None, op3 = None):
+async def roll_dice_dm(ctx, *ops):
     character = get_character(ctx.author.id)
-    string, embed = get_roll_results(character, op1, op2, op3)
+    string, embed = get_roll_results(character, *ops)
     dm = get_member(dungeon_master_id)
 
     if ctx.author != dm or not embed:


### PR DESCRIPTION
- Refactored roll commands to allow for any arbitrary number of arguments (doubling up on things other than flat modifiers will still result in an error)
- Can now add an unlimited number of flat modifiers to the roll command
- Cleaned up a lot of the parsing code to organize results into individual categories (eg: stat modifier is no longer internally ambiguous as an int or string, it will now always be categorized as a string and we now have flat modifier for literal ints).